### PR TITLE
feat: implement GET /api/entries with SearchEntries use case

### DIFF
--- a/src/app/api/entries/route.ts
+++ b/src/app/api/entries/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ZodError } from "zod";
+import { requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
+import { createSearchEntriesUseCase } from "@/interface/http/use-case-factory";
+import { searchEntriesQuerySchema } from "@/interface/http/schemas/search-entries-query-schema";
+
+export async function GET(request: NextRequest) {
+  try {
+    const userId = await requireUserId();
+    const query = searchEntriesQuerySchema.parse(
+      Object.fromEntries(request.nextUrl.searchParams.entries()),
+    );
+
+    const useCase = createSearchEntriesUseCase();
+    const entries = await useCase.execute({
+      userId,
+      feedId: query.feedId,
+      folderId: query.folderId,
+      tagId: query.tagId,
+      unreadOnly: query.unread,
+      search: query.search,
+      limit: query.limit,
+      cursor: query.cursor,
+    });
+
+    return NextResponse.json({ entries }, { status: 200 });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: "Invalid query parameters", issues: error.issues },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/application/use-cases/index.ts
+++ b/src/application/use-cases/index.ts
@@ -1,2 +1,3 @@
 export * from "./mark-entry-read";
 export * from "./register-feed";
+export * from "./search-entries";

--- a/src/application/use-cases/search-entries.ts
+++ b/src/application/use-cases/search-entries.ts
@@ -1,0 +1,50 @@
+import type { Entry } from "@/domain/entities";
+import type { EntryRepository, SearchRepository } from "@/application/ports";
+
+export interface SearchEntriesInput {
+  userId: string;
+  feedId?: string;
+  folderId?: string;
+  tagId?: string;
+  unreadOnly?: boolean;
+  search?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface SearchEntriesDependencies {
+  entryRepository: EntryRepository;
+  searchRepository: SearchRepository;
+}
+
+export class SearchEntries {
+  constructor(private readonly deps: SearchEntriesDependencies) {}
+
+  async execute(input: SearchEntriesInput): Promise<Entry[]> {
+    const query = input.search?.trim();
+
+    if (query) {
+      return this.deps.searchRepository.searchEntries({
+        userId: input.userId,
+        query,
+        feedId: input.feedId,
+        folderId: input.folderId,
+        tagId: input.tagId,
+        unreadOnly: input.unreadOnly,
+        limit: input.limit,
+        cursor: input.cursor,
+      });
+    }
+
+    return this.deps.entryRepository.listByFilter({
+      userId: input.userId,
+      feedId: input.feedId,
+      folderId: input.folderId,
+      tagId: input.tagId,
+      unreadOnly: input.unreadOnly,
+      search: undefined,
+      limit: input.limit,
+      cursor: input.cursor,
+    });
+  }
+}

--- a/src/interface/http/schemas/search-entries-query-schema.ts
+++ b/src/interface/http/schemas/search-entries-query-schema.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+const unreadSchema = z
+  .enum(["1", "0", "true", "false"])
+  .optional()
+  .transform((value) => {
+    if (!value) {
+      return undefined;
+    }
+    return value === "1" || value === "true";
+  });
+
+export const searchEntriesQuerySchema = z.object({
+  feedId: z.string().uuid().optional(),
+  folderId: z.string().uuid().optional(),
+  tagId: z.string().uuid().optional(),
+  unread: unreadSchema,
+  search: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value && value.length > 0 ? value : undefined)),
+  limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  cursor: z.string().optional(),
+});
+
+export type SearchEntriesQuery = z.infer<typeof searchEntriesQuerySchema>;

--- a/src/interface/http/use-case-factory.ts
+++ b/src/interface/http/use-case-factory.ts
@@ -1,4 +1,4 @@
-import { MarkEntryRead, RegisterFeed } from "@/application/use-cases";
+import { MarkEntryRead, RegisterFeed, SearchEntries } from "@/application/use-cases";
 import { createRepositories } from "@/infrastructure/db";
 import { RssFetcherHttp } from "@/infrastructure/rss/rss-fetcher-http";
 
@@ -17,5 +17,12 @@ export function createRegisterFeedUseCase(): RegisterFeed {
 export function createMarkEntryReadUseCase(): MarkEntryRead {
   return new MarkEntryRead({
     entryRepository: repositories.entryRepository,
+  });
+}
+
+export function createSearchEntriesUseCase(): SearchEntries {
+  return new SearchEntries({
+    entryRepository: repositories.entryRepository,
+    searchRepository: repositories.searchRepository,
   });
 }


### PR DESCRIPTION
Closes #2

## Summary
- add `SearchEntries` use case
- add `GET /api/entries` route for feed/folder/tag/unread/search filters
- validate query parameters with Zod schema
- wire `createSearchEntriesUseCase` in use-case factory

## Verification
- npm run lint
- npm run build
