### PR TITLE
feat: add unread and bookmark entry actions

### DIFF
--- a/src/app/api/entries/[id]/bookmark/route.ts
+++ b/src/app/api/entries/[id]/bookmark/route.ts
@@ -1,0 +1,34 @@
+import { EntryNotFoundError } from "@/application/use-cases";
+import { requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
+import { createToggleBookmarkUseCase } from "@/interface/http/use-case-factory";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export async function POST(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const userId = await requireUserId();
+    const { id } = await context.params;
+
+    const useCase = createToggleBookmarkUseCase();
+    const result = await useCase.execute({
+      userId,
+      entryId: id,
+      isBookmarked: true,
+    });
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+
+    if (error instanceof EntryNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/app/api/entries/[id]/unbookmark/route.ts
+++ b/src/app/api/entries/[id]/unbookmark/route.ts
@@ -1,0 +1,34 @@
+import { EntryNotFoundError } from "@/application/use-cases";
+import { requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
+import { createToggleBookmarkUseCase } from "@/interface/http/use-case-factory";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export async function POST(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const userId = await requireUserId();
+    const { id } = await context.params;
+
+    const useCase = createToggleBookmarkUseCase();
+    const result = await useCase.execute({
+      userId,
+      entryId: id,
+      isBookmarked: false,
+    });
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+
+    if (error instanceof EntryNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/app/api/entries/[id]/unread/route.ts
+++ b/src/app/api/entries/[id]/unread/route.ts
@@ -1,0 +1,33 @@
+import { EntryNotFoundError } from "@/application/use-cases";
+import { requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
+import { createMarkEntryUnreadUseCase } from "@/interface/http/use-case-factory";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export async function POST(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const userId = await requireUserId();
+    const { id } = await context.params;
+
+    const useCase = createMarkEntryUnreadUseCase();
+    const result = await useCase.execute({
+      userId,
+      entryId: id,
+    });
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+
+    if (error instanceof EntryNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/application/use-cases/index.ts
+++ b/src/application/use-cases/index.ts
@@ -1,3 +1,5 @@
 export * from "./mark-entry-read";
+export * from "./mark-entry-unread";
 export * from "./register-feed";
 export * from "./search-entries";
+export * from "./toggle-bookmark";

--- a/src/application/use-cases/mark-entry-unread.ts
+++ b/src/application/use-cases/mark-entry-unread.ts
@@ -1,0 +1,32 @@
+import type { UserEntry } from "@/domain/entities";
+import type { EntryRepository } from "@/application/ports";
+import { EntryNotFoundError } from "./mark-entry-read";
+
+export interface MarkEntryUnreadInput {
+  userId: string;
+  entryId: string;
+}
+
+export interface MarkEntryUnreadDependencies {
+  entryRepository: EntryRepository;
+}
+
+export class MarkEntryUnread {
+  constructor(private readonly deps: MarkEntryUnreadDependencies) {}
+
+  async execute(input: MarkEntryUnreadInput): Promise<UserEntry> {
+    const entry = await this.deps.entryRepository.findByIdForUser({
+      userId: input.userId,
+      entryId: input.entryId,
+    });
+
+    if (!entry) {
+      throw new EntryNotFoundError(input.entryId);
+    }
+
+    return this.deps.entryRepository.markAsUnread({
+      userId: input.userId,
+      entryId: input.entryId,
+    });
+  }
+}

--- a/src/application/use-cases/toggle-bookmark.ts
+++ b/src/application/use-cases/toggle-bookmark.ts
@@ -1,0 +1,34 @@
+import type { UserEntry } from "@/domain/entities";
+import type { EntryRepository } from "@/application/ports";
+import { EntryNotFoundError } from "./mark-entry-read";
+
+export interface ToggleBookmarkInput {
+  userId: string;
+  entryId: string;
+  isBookmarked: boolean;
+}
+
+export interface ToggleBookmarkDependencies {
+  entryRepository: EntryRepository;
+}
+
+export class ToggleBookmark {
+  constructor(private readonly deps: ToggleBookmarkDependencies) {}
+
+  async execute(input: ToggleBookmarkInput): Promise<UserEntry> {
+    const entry = await this.deps.entryRepository.findByIdForUser({
+      userId: input.userId,
+      entryId: input.entryId,
+    });
+
+    if (!entry) {
+      throw new EntryNotFoundError(input.entryId);
+    }
+
+    return this.deps.entryRepository.toggleBookmark({
+      userId: input.userId,
+      entryId: input.entryId,
+      isBookmarked: input.isBookmarked,
+    });
+  }
+}

--- a/src/interface/http/use-case-factory.ts
+++ b/src/interface/http/use-case-factory.ts
@@ -1,4 +1,10 @@
-import { MarkEntryRead, RegisterFeed, SearchEntries } from "@/application/use-cases";
+import {
+  MarkEntryRead,
+  MarkEntryUnread,
+  RegisterFeed,
+  SearchEntries,
+  ToggleBookmark,
+} from "@/application/use-cases";
 import { createRepositories } from "@/infrastructure/db";
 import { RssFetcherHttp } from "@/infrastructure/rss/rss-fetcher-http";
 
@@ -16,6 +22,18 @@ export function createRegisterFeedUseCase(): RegisterFeed {
 
 export function createMarkEntryReadUseCase(): MarkEntryRead {
   return new MarkEntryRead({
+    entryRepository: repositories.entryRepository,
+  });
+}
+
+export function createMarkEntryUnreadUseCase(): MarkEntryUnread {
+  return new MarkEntryUnread({
+    entryRepository: repositories.entryRepository,
+  });
+}
+
+export function createToggleBookmarkUseCase(): ToggleBookmark {
+  return new ToggleBookmark({
     entryRepository: repositories.entryRepository,
   });
 }


### PR DESCRIPTION
Closes #3

## Summary
- add `MarkEntryUnread` use case
- add `ToggleBookmark` use case
- add routes:
  - `POST /api/entries/:id/unread`
  - `POST /api/entries/:id/bookmark`
  - `POST /api/entries/:id/unbookmark`
- wire use-case factory for unread/bookmark actions

## Verification
- npm run lint
- npm run build
