### PR TITLE
feat: add minimal web interface for verification flow

### DIFF
--- a/src/interface/ui/components/home-client.tsx
+++ b/src/interface/ui/components/home-client.tsx
@@ -1,49 +1,238 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
 import { useFeedFormStore } from "@/interface/ui/stores/feed-form-store";
 
-interface HealthResponse {
-  ok: boolean;
-  now: string;
+interface EntryItem {
+  id: string;
+  title: string;
+  url: string;
+  author: string | null;
+  publishedAt: string | null;
 }
 
-async function fetchHealth(): Promise<HealthResponse> {
-  const response = await fetch("/api/health");
-  if (!response.ok) {
-    throw new Error("Failed to fetch health");
+interface EntriesResponse {
+  entries: EntryItem[];
+}
+
+class UnauthorizedApiError extends Error {
+  constructor() {
+    super("Unauthorized");
+    this.name = "UnauthorizedApiError";
   }
-  return response.json() as Promise<HealthResponse>;
+}
+
+async function fetchEntries(input: {
+  unreadOnly: boolean;
+  search: string;
+}): Promise<EntriesResponse> {
+  const params = new URLSearchParams();
+  if (input.unreadOnly) {
+    params.set("unread", "1");
+  }
+  if (input.search.trim()) {
+    params.set("search", input.search.trim());
+  }
+
+  const response = await fetch(`/api/entries?${params.toString()}`);
+  if (response.status === 401) {
+    throw new UnauthorizedApiError();
+  }
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? "Failed to fetch entries");
+  }
+  return response.json() as Promise<EntriesResponse>;
+}
+
+async function createFeed(url: string): Promise<void> {
+  const response = await fetch("/api/feeds", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+
+  if (response.status === 401) {
+    throw new UnauthorizedApiError();
+  }
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? "Failed to register feed");
+  }
+}
+
+async function postEntryAction(entryId: string, action: "read" | "unread" | "bookmark" | "unbookmark") {
+  const response = await fetch(`/api/entries/${entryId}/${action}`, { method: "POST" });
+  if (response.status === 401) {
+    throw new UnauthorizedApiError();
+  }
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `Failed to ${action}`);
+  }
 }
 
 export function HomeClient() {
+  const queryClient = useQueryClient();
   const { draftUrl, setDraftUrl, clear } = useFeedFormStore();
-  const health = useQuery({ queryKey: ["health"], queryFn: fetchHealth });
+
+  const [search, setSearch] = useState("");
+  const [unreadOnly, setUnreadOnly] = useState(false);
+  const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
+
+  const entriesQuery = useQuery({
+    queryKey: ["entries", { unreadOnly, search }],
+    queryFn: () => fetchEntries({ unreadOnly, search }),
+  });
+
+  const createFeedMutation = useMutation({
+    mutationFn: createFeed,
+    onSuccess: async () => {
+      clear();
+      await queryClient.invalidateQueries({ queryKey: ["entries"] });
+    },
+  });
+
+  const entryActionMutation = useMutation({
+    mutationFn: async (input: {
+      entryId: string;
+      action: "read" | "unread" | "bookmark" | "unbookmark";
+    }) => {
+      setActiveEntryId(input.entryId);
+      await postEntryAction(input.entryId, input.action);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["entries"] });
+    },
+    onSettled: () => {
+      setActiveEntryId(null);
+    },
+  });
+
+  const unauthorized = entriesQuery.error instanceof UnauthorizedApiError;
+  const errorMessage = useMemo(() => {
+    if (entriesQuery.error && !(entriesQuery.error instanceof UnauthorizedApiError)) {
+      return entriesQuery.error.message;
+    }
+    if (createFeedMutation.error && !(createFeedMutation.error instanceof UnauthorizedApiError)) {
+      return createFeedMutation.error.message;
+    }
+    if (entryActionMutation.error && !(entryActionMutation.error instanceof UnauthorizedApiError)) {
+      return entryActionMutation.error.message;
+    }
+    return null;
+  }, [createFeedMutation.error, entriesQuery.error, entryActionMutation.error]);
 
   return (
-    <section className="w-full rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
-      <h1 className="text-2xl font-semibold text-slate-900">RSS Reader</h1>
-      <p className="mt-3 text-slate-600">Tailwind + Zustand + TanStack Query + Zod ready.</p>
+    <section className="w-full space-y-6 rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900">RSS Reader</h1>
+        <p className="mt-2 text-sm text-slate-600">Minimal verification UI for feeds and entries.</p>
+      </header>
 
-      <div className="mt-6 space-y-2 text-sm text-slate-600">
-        <p>Status: {health.isLoading ? "loading..." : health.data?.ok ? "ok" : "error"}</p>
-        <p>Server time: {health.data?.now ?? "-"}</p>
+      <div className="rounded-lg border border-slate-200 p-4">
+        <h2 className="text-sm font-semibold text-slate-900">1) Register Feed</h2>
+        <div className="mt-3 flex gap-2">
+          <input
+            value={draftUrl}
+            onChange={(e) => setDraftUrl(e.target.value)}
+            placeholder="https://example.com/feed.xml"
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+          />
+          <button
+            type="button"
+            onClick={() => createFeedMutation.mutate(draftUrl)}
+            disabled={!draftUrl.trim() || createFeedMutation.isPending}
+            className="rounded-md bg-slate-900 px-3 py-2 text-sm text-white disabled:opacity-60"
+          >
+            {createFeedMutation.isPending ? "Adding..." : "Add"}
+          </button>
+          <button
+            type="button"
+            onClick={clear}
+            className="rounded-md border border-slate-300 px-3 py-2 text-sm"
+          >
+            Clear
+          </button>
+        </div>
       </div>
 
-      <div className="mt-6 flex gap-2">
-        <input
-          value={draftUrl}
-          onChange={(e) => setDraftUrl(e.target.value)}
-          placeholder="https://example.com/feed.xml"
-          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
-        />
-        <button
-          type="button"
-          onClick={clear}
-          className="rounded-md border border-slate-300 px-3 py-2 text-sm"
-        >
-          Clear
-        </button>
+      <div className="rounded-lg border border-slate-200 p-4">
+        <h2 className="text-sm font-semibold text-slate-900">2) Entries</h2>
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="search title/content"
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm sm:w-80"
+          />
+          <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+            <input
+              type="checkbox"
+              checked={unreadOnly}
+              onChange={(e) => setUnreadOnly(e.target.checked)}
+            />
+            unread only
+          </label>
+          <button
+            type="button"
+            onClick={() => entriesQuery.refetch()}
+            className="rounded-md border border-slate-300 px-3 py-2 text-sm"
+          >
+            Refresh
+          </button>
+        </div>
+
+        {unauthorized ? (
+          <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+            Sign in is required. Open{" "}
+            <Link className="underline" href="/api/auth/signin">
+              /api/auth/signin
+            </Link>
+            .
+          </div>
+        ) : null}
+
+        {errorMessage ? (
+          <p className="mt-4 text-sm text-red-700">{errorMessage}</p>
+        ) : null}
+
+        <ul className="mt-4 space-y-2">
+          {entriesQuery.isLoading ? (
+            <li className="text-sm text-slate-600">Loading entries...</li>
+          ) : null}
+
+          {!entriesQuery.isLoading && (entriesQuery.data?.entries.length ?? 0) === 0 ? (
+            <li className="text-sm text-slate-600">No entries found.</li>
+          ) : null}
+
+          {entriesQuery.data?.entries.map((entry) => (
+            <li key={entry.id} className="rounded-md border border-slate-200 p-3">
+              <a href={entry.url} target="_blank" rel="noreferrer" className="font-medium text-slate-900 underline">
+                {entry.title}
+              </a>
+              <p className="mt-1 text-xs text-slate-500">
+                {entry.author ?? "Unknown author"}
+                {entry.publishedAt ? ` / ${new Date(entry.publishedAt).toLocaleString()}` : ""}
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {(["read", "unread", "bookmark", "unbookmark"] as const).map((action) => (
+                  <button
+                    key={action}
+                    type="button"
+                    onClick={() => entryActionMutation.mutate({ entryId: entry.id, action })}
+                    disabled={entryActionMutation.isPending && activeEntryId === entry.id}
+                    className="rounded-md border border-slate-300 px-2 py-1 text-xs uppercase"
+                  >
+                    {action}
+                  </button>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
   );


### PR DESCRIPTION
Closes #14

## Summary
- expand home UI into a minimal verification surface
- support feed registration from browser (`POST /api/feeds`)
- support entries listing (`GET /api/entries`) with unread/search filters
- support entry actions (`read/unread/bookmark/unbookmark`)
- show sign-in guidance when API returns 401
- show API error messages in UI

## Verification
- npm run lint
- npm run build
