### PR TITLE
fix: handle FK user constraints and harden RSS fetcher

### DIFF
--- a/src/app/api/entries/[id]/bookmark/route.ts
+++ b/src/app/api/entries/[id]/bookmark/route.ts
@@ -1,5 +1,5 @@
 import { EntryNotFoundError } from "@/application/use-cases";
-import { requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
+import { InvalidSessionError, requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
 import { createToggleBookmarkUseCase } from "@/interface/http/use-case-factory";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
@@ -21,7 +21,7 @@ export async function POST(
 
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
-    if (error instanceof UnauthorizedError) {
+    if (error instanceof UnauthorizedError || error instanceof InvalidSessionError) {
       return NextResponse.json({ error: error.message }, { status: 401 });
     }
 

--- a/src/app/api/entries/[id]/read/route.ts
+++ b/src/app/api/entries/[id]/read/route.ts
@@ -1,5 +1,5 @@
 import { EntryNotFoundError } from "@/application/use-cases";
-import { requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
+import { InvalidSessionError, requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
 import { createMarkEntryReadUseCase } from "@/interface/http/use-case-factory";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -19,7 +19,7 @@ export async function POST(
 
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
-    if (error instanceof UnauthorizedError) {
+    if (error instanceof UnauthorizedError || error instanceof InvalidSessionError) {
       return NextResponse.json({ error: error.message }, { status: 401 });
     }
 

--- a/src/app/api/entries/[id]/unbookmark/route.ts
+++ b/src/app/api/entries/[id]/unbookmark/route.ts
@@ -1,5 +1,5 @@
 import { EntryNotFoundError } from "@/application/use-cases";
-import { requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
+import { InvalidSessionError, requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
 import { createToggleBookmarkUseCase } from "@/interface/http/use-case-factory";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
@@ -21,7 +21,7 @@ export async function POST(
 
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
-    if (error instanceof UnauthorizedError) {
+    if (error instanceof UnauthorizedError || error instanceof InvalidSessionError) {
       return NextResponse.json({ error: error.message }, { status: 401 });
     }
 

--- a/src/app/api/entries/[id]/unread/route.ts
+++ b/src/app/api/entries/[id]/unread/route.ts
@@ -1,5 +1,5 @@
 import { EntryNotFoundError } from "@/application/use-cases";
-import { requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
+import { InvalidSessionError, requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
 import { createMarkEntryUnreadUseCase } from "@/interface/http/use-case-factory";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
@@ -20,7 +20,7 @@ export async function POST(
 
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
-    if (error instanceof UnauthorizedError) {
+    if (error instanceof UnauthorizedError || error instanceof InvalidSessionError) {
       return NextResponse.json({ error: error.message }, { status: 401 });
     }
 

--- a/src/app/api/entries/route.ts
+++ b/src/app/api/entries/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ZodError } from "zod";
-import { requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
+import { InvalidSessionError, requireUserId, UnauthorizedError } from "@/interface/http/auth-user";
 import { createSearchEntriesUseCase } from "@/interface/http/use-case-factory";
 import { searchEntriesQuerySchema } from "@/interface/http/schemas/search-entries-query-schema";
 
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ entries }, { status: 200 });
   } catch (error) {
-    if (error instanceof UnauthorizedError) {
+    if (error instanceof UnauthorizedError || error instanceof InvalidSessionError) {
       return NextResponse.json({ error: error.message }, { status: 401 });
     }
 

--- a/src/application/ports/user-repository.ts
+++ b/src/application/ports/user-repository.ts
@@ -3,7 +3,12 @@ import type { PublicProfile, User } from "@/domain/entities";
 export interface UserRepository {
   findById(id: string): Promise<User | null>;
   findByEmail(email: string): Promise<User | null>;
-  create(input: { email: string; name?: string | null; image?: string | null }): Promise<User>;
+  create(input: {
+    id?: string;
+    email: string;
+    name?: string | null;
+    image?: string | null;
+  }): Promise<User>;
   findPublicProfileBySlug(slug: string): Promise<PublicProfile | null>;
   upsertPublicProfile(input: {
     userId: string;

--- a/src/infrastructure/db/in-memory-user-repository.ts
+++ b/src/infrastructure/db/in-memory-user-repository.ts
@@ -12,17 +12,25 @@ export class InMemoryUserRepository implements UserRepository {
   }
 
   async create(input: {
+    id?: string;
     email: string;
     name?: string | null;
     image?: string | null;
   }): Promise<User> {
+    if (input.id) {
+      const existingById = await this.findById(input.id);
+      if (existingById) {
+        return existingById;
+      }
+    }
+
     const existing = await this.findByEmail(input.email);
     if (existing) {
       return existing;
     }
 
     const user: User = {
-      id: createId(),
+      id: input.id ?? createId(),
       email: input.email,
       name: input.name ?? null,
       image: input.image ?? null,

--- a/src/infrastructure/db/turso-user-repository.ts
+++ b/src/infrastructure/db/turso-user-repository.ts
@@ -71,12 +71,20 @@ export class TursoUserRepository implements UserRepository {
   }
 
   async create(input: {
+    id?: string;
     email: string;
     name?: string | null;
     image?: string | null;
   }): Promise<User> {
+    if (input.id) {
+      const existingById = await this.findById(input.id);
+      if (existingById) {
+        return existingById;
+      }
+    }
+
     const db = getTursoClient();
-    const id = crypto.randomUUID();
+    const id = input.id ?? crypto.randomUUID();
 
     await db.execute({
       sql: `

--- a/src/infrastructure/rss/rss-fetcher-http.ts
+++ b/src/infrastructure/rss/rss-fetcher-http.ts
@@ -40,6 +40,12 @@ function parseDate(value: string | null): Date | null {
 export class RssFetcherHttp implements RssFetcher {
   async fetchFeed(input: FetchFeedInput): Promise<FetchedFeed> {
     const headers = new Headers();
+    headers.set(
+      "Accept",
+      "application/rss+xml, application/atom+xml, application/xml, text/xml;q=0.9, */*;q=0.1",
+    );
+    headers.set("User-Agent", "rss-reader/0.1 (+https://github.com/yusuke0627/rss_reader)");
+    headers.set("Accept-Language", "ja,en-US;q=0.8,en;q=0.6");
     if (input.etag) {
       headers.set("If-None-Match", input.etag);
     }
@@ -51,6 +57,7 @@ export class RssFetcherHttp implements RssFetcher {
       method: "GET",
       headers,
       redirect: "follow",
+      signal: AbortSignal.timeout(20_000),
     });
 
     if (response.status === 304) {

--- a/src/interface/http/auth-user.ts
+++ b/src/interface/http/auth-user.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/auth";
+import { createRepositories } from "@/infrastructure/db";
 
 export class UnauthorizedError extends Error {
   constructor() {
@@ -7,11 +8,32 @@ export class UnauthorizedError extends Error {
   }
 }
 
+export class InvalidSessionError extends Error {
+  constructor() {
+    super("Authenticated session is missing user email");
+    this.name = "InvalidSessionError";
+  }
+}
+
 export async function requireUserId(): Promise<string> {
   const session = await auth();
-  const userId = session?.user?.id;
+  const user = session?.user;
+  const userId = user?.id;
   if (!userId) {
     throw new UnauthorizedError();
   }
+
+  if (!user?.email) {
+    throw new InvalidSessionError();
+  }
+
+  const repositories = createRepositories();
+  await repositories.userRepository.create({
+    id: userId,
+    email: user.email,
+    name: user.name ?? null,
+    image: user.image ?? null,
+  });
+
   return userId;
 }


### PR DESCRIPTION
Closes #16

## Summary
- upsert authenticated user record during `requireUserId()` to avoid FK constraint failures
- extend `UserRepository.create` to optionally accept explicit `id`
- update Turso/in-memory user repository implementations for id-aware upsert behavior
- treat invalid auth session as 401 across entries/feeds routes
- harden RSS fetcher with explicit accept/user-agent/language headers and timeout
- include dev-only internal error detail in feeds route for faster diagnosis

## Verification
- npm run lint
- npm run build
- manually verified adding `https://gigazine.net/news/rss_2.0/` no longer returns FK 500
