### PR TITLE
docs: add beginner code-reading guide and architecture comments

### DIFF
--- a/docs/code-reading-for-beginners.md
+++ b/docs/code-reading-for-beginners.md
@@ -1,0 +1,94 @@
+# Next.js + クリーンアーキテクチャ初心者向けコードリーディングガイド
+
+このドキュメントは「どこから読めば迷わないか」を目的にしています。
+
+## 0. まず前提（このプロジェクトの依存方向）
+- `interface` / `app`（UI・HTTP）
+- `application`（ユースケース）
+- `domain`（型・ビジネスの中心）
+- `infrastructure`（DB/外部API実装）
+
+依存は **外側 -> 内側** です。
+`application` は具体実装（Turso/HTTP）を知らず、`ports` だけに依存します。
+
+## 1. 最短で全体像を掴む読み順
+1. `/Users/arakaki/dev/rss_reader/src/app/page.tsx`
+2. `/Users/arakaki/dev/rss_reader/src/interface/ui/components/home-client.tsx`
+3. `/Users/arakaki/dev/rss_reader/src/app/api/feeds/route.ts`
+4. `/Users/arakaki/dev/rss_reader/src/interface/http/use-case-factory.ts`
+5. `/Users/arakaki/dev/rss_reader/src/application/use-cases/register-feed.ts`
+6. `/Users/arakaki/dev/rss_reader/src/application/ports/*.ts`
+7. `/Users/arakaki/dev/rss_reader/src/infrastructure/db/repository-factory.ts`
+8. `/Users/arakaki/dev/rss_reader/src/infrastructure/db/turso-*.ts`
+
+この順で読むと、
+「UI -> API -> UseCase -> Port -> 実装」の流れが一周できます。
+
+## 2. ルーティング層（Next.js App Router）の見方
+- APIは `src/app/api/**/route.ts`
+- 役割は「入力受け取り・バリデーション・UseCase呼び出し・HTTPレスポンス変換」
+- ビジネス判断は route に書かず UseCase へ寄せる
+
+注目ファイル:
+- `/Users/arakaki/dev/rss_reader/src/app/api/feeds/route.ts`
+- `/Users/arakaki/dev/rss_reader/src/app/api/entries/route.ts`
+
+## 3. UseCase（application）の見方
+UseCase は「1機能の業務フロー」です。
+
+例:
+- `RegisterFeed`: URL検証 -> フィード取得 -> feed/subscription保存 -> entries保存
+- `MarkEntryRead`: 対象entryが自分に見えるか確認 -> 既読化
+
+注目ファイル:
+- `/Users/arakaki/dev/rss_reader/src/application/use-cases/register-feed.ts`
+- `/Users/arakaki/dev/rss_reader/src/application/use-cases/mark-entry-read.ts`
+- `/Users/arakaki/dev/rss_reader/src/application/use-cases/search-entries.ts`
+
+## 4. Ports（application/ports）の見方
+Ports は「UseCaseが期待する機能のインターフェース」です。
+
+ここに具体実装は書かれません。
+例えば `FeedRepository` が「何をできるべきか」だけを定義します。
+
+注目ファイル:
+- `/Users/arakaki/dev/rss_reader/src/application/ports/feed-repository.ts`
+- `/Users/arakaki/dev/rss_reader/src/application/ports/entry-repository.ts`
+- `/Users/arakaki/dev/rss_reader/src/application/ports/user-repository.ts`
+
+## 5. Infrastructure（実装）の見方
+同じ Port に対して実装が複数あります。
+
+- Turso実装: `turso-*.ts`
+- 開発用 in-memory 実装: `in-memory-*.ts`
+- 切替は `repository-factory.ts`
+
+注目ファイル:
+- `/Users/arakaki/dev/rss_reader/src/infrastructure/db/repository-factory.ts`
+- `/Users/arakaki/dev/rss_reader/src/infrastructure/db/turso-entry-repository.ts`
+- `/Users/arakaki/dev/rss_reader/src/infrastructure/rss/rss-fetcher-http.ts`
+
+## 6. 認証周りの見方
+- Auth.js 設定: `/Users/arakaki/dev/rss_reader/src/auth.ts`
+- API側の認証ゲート: `/Users/arakaki/dev/rss_reader/src/interface/http/auth-user.ts`
+
+`requireUserId()` は現在、セッション確認だけでなく users テーブルへの upsert も担当します。
+（外部キー制約違反を防ぐため）
+
+## 7. よくある混乱ポイント
+- route.ts に業務ロジックを書きすぎる
+- UseCase が直接 Turso を呼ぶ（ports違反）
+- domain に zod や next 依存を入れてしまう
+- フィルタや検索の責務が route と repository で重複する
+
+## 8. 実際に追うべきデバッグ手順
+例: フィード登録で500になるとき
+1. routeの `catch` で `detail` を確認
+2. `RegisterFeed` のどこで落ちるか（fetch/save/subscription）を特定
+3. `Turso*Repository` の SQL と制約を確認
+4. 依存注入が意図どおり Turso実装を使っているか確認
+
+## 9. 学習の次ステップ
+1. `Issue #6`（Cron同期）で UseCase -> Port -> Turso 実装の追加を体験
+2. `Issue #7`（Auth users同期）を読む・改善する
+3. APIエラー形式統一（`code/message`）で route層の設計を揃える

--- a/src/app/api/entries/[id]/bookmark/route.ts
+++ b/src/app/api/entries/[id]/bookmark/route.ts
@@ -9,9 +9,11 @@ export async function POST(
   context: { params: Promise<{ id: string }> },
 ) {
   try {
+    // 認証と users整合を通したうえで対象entryを更新する。
     const userId = await requireUserId();
     const { id } = await context.params;
 
+    // route層ではUseCase呼び出しのみに集中する。
     const useCase = createToggleBookmarkUseCase();
     const result = await useCase.execute({
       userId,

--- a/src/app/api/entries/[id]/read/route.ts
+++ b/src/app/api/entries/[id]/read/route.ts
@@ -8,9 +8,11 @@ export async function POST(
   context: { params: Promise<{ id: string }> },
 ) {
   try {
+    // 認証と users整合を通したうえで対象entryを更新する。
     const userId = await requireUserId();
     const { id } = await context.params;
 
+    // route層ではUseCase呼び出しのみに集中する。
     const useCase = createMarkEntryReadUseCase();
     const result = await useCase.execute({
       userId,

--- a/src/app/api/entries/[id]/unbookmark/route.ts
+++ b/src/app/api/entries/[id]/unbookmark/route.ts
@@ -9,9 +9,11 @@ export async function POST(
   context: { params: Promise<{ id: string }> },
 ) {
   try {
+    // 認証と users整合を通したうえで対象entryを更新する。
     const userId = await requireUserId();
     const { id } = await context.params;
 
+    // route層ではUseCase呼び出しのみに集中する。
     const useCase = createToggleBookmarkUseCase();
     const result = await useCase.execute({
       userId,

--- a/src/app/api/entries/[id]/unread/route.ts
+++ b/src/app/api/entries/[id]/unread/route.ts
@@ -9,9 +9,11 @@ export async function POST(
   context: { params: Promise<{ id: string }> },
 ) {
   try {
+    // 認証と users整合を通したうえで対象entryを更新する。
     const userId = await requireUserId();
     const { id } = await context.params;
 
+    // route層ではUseCase呼び出しのみに集中する。
     const useCase = createMarkEntryUnreadUseCase();
     const result = await useCase.execute({
       userId,

--- a/src/app/api/entries/route.ts
+++ b/src/app/api/entries/route.ts
@@ -6,11 +6,14 @@ import { searchEntriesQuerySchema } from "@/interface/http/schemas/search-entrie
 
 export async function GET(request: NextRequest) {
   try {
+    // 1) 認証と users整合。
     const userId = await requireUserId();
+    // 2) クエリ文字列を zod で構造化。
     const query = searchEntriesQuerySchema.parse(
       Object.fromEntries(request.nextUrl.searchParams.entries()),
     );
 
+    // 3) 一覧取得ロジックは UseCase に委譲。
     const useCase = createSearchEntriesUseCase();
     const entries = await useCase.execute({
       userId,

--- a/src/app/api/feeds/route.ts
+++ b/src/app/api/feeds/route.ts
@@ -7,9 +7,12 @@ import { ZodError } from "zod";
 
 export async function POST(request: NextRequest) {
   try {
+    // 1) 認証と users整合を通す。
     const userId = await requireUserId();
+    // 2) リクエストを zod で検証。
     const body = registerFeedSchema.parse(await request.json());
 
+    // 3) UseCase に業務ロジックを委譲。
     const useCase = createRegisterFeedUseCase();
     const result = await useCase.execute({
       userId,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body>
+        {/* Client-side provider (TanStack Query) の注入ポイント */}
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { HomeClient } from "@/interface/ui/components/home-client";
 export default function Home() {
   return (
     <main className="mx-auto flex min-h-screen max-w-4xl items-center justify-center p-8">
+      {/* 実操作の入り口は HomeClient に集約 */}
       <HomeClient />
     </main>
   );

--- a/src/application/ports/entry-repository.ts
+++ b/src/application/ports/entry-repository.ts
@@ -1,5 +1,7 @@
 import type { Entry, UserEntry } from "@/domain/entities";
 
+// Entryの取得・更新に関する契約。
+// `user_entry` の read/bookmark 状態はここ経由で更新する。
 export interface EntryFilter {
   userId: string;
   feedId?: string;

--- a/src/application/ports/feed-repository.ts
+++ b/src/application/ports/feed-repository.ts
@@ -1,5 +1,7 @@
 import type { Feed, Subscription } from "@/domain/entities";
 
+// UseCase から見た「フィード永続化」の契約。
+// 実体は Turso 実装 / in-memory 実装で差し替える。
 export interface CreateFeedInput {
   url: string;
   title: string;

--- a/src/application/ports/search-repository.ts
+++ b/src/application/ports/search-repository.ts
@@ -1,5 +1,6 @@
 import type { Entry } from "@/domain/entities";
 
+// FTS など検索専用のI/Oを切り離すための契約。
 export interface SearchEntriesInput {
   userId: string;
   query: string;

--- a/src/application/ports/user-repository.ts
+++ b/src/application/ports/user-repository.ts
@@ -1,5 +1,6 @@
 import type { PublicProfile, User } from "@/domain/entities";
 
+// 認証ユーザーの同期と公開プロフィール管理の契約。
 export interface UserRepository {
   findById(id: string): Promise<User | null>;
   findByEmail(email: string): Promise<User | null>;

--- a/src/application/use-cases/mark-entry-read.ts
+++ b/src/application/use-cases/mark-entry-read.ts
@@ -22,6 +22,7 @@ export class MarkEntryRead {
   constructor(private readonly deps: MarkEntryReadDependencies) {}
 
   async execute(input: MarkEntryReadInput): Promise<UserEntry> {
+    // 自分がアクセス可能なentryかを先に検証する。
     const entry = await this.deps.entryRepository.findByIdForUser({
       userId: input.userId,
       entryId: input.entryId,
@@ -31,6 +32,7 @@ export class MarkEntryRead {
       throw new EntryNotFoundError(input.entryId);
     }
 
+    // user_entry の冪等upsertは repository 側に任せる。
     return this.deps.entryRepository.markAsRead({
       userId: input.userId,
       entryId: input.entryId,

--- a/src/application/use-cases/mark-entry-unread.ts
+++ b/src/application/use-cases/mark-entry-unread.ts
@@ -15,6 +15,7 @@ export class MarkEntryUnread {
   constructor(private readonly deps: MarkEntryUnreadDependencies) {}
 
   async execute(input: MarkEntryUnreadInput): Promise<UserEntry> {
+    // read と同様、先に可視性チェックしてから状態更新する。
     const entry = await this.deps.entryRepository.findByIdForUser({
       userId: input.userId,
       entryId: input.entryId,

--- a/src/application/use-cases/search-entries.ts
+++ b/src/application/use-cases/search-entries.ts
@@ -24,6 +24,7 @@ export class SearchEntries {
     const query = input.search?.trim();
 
     if (query) {
+      // 検索語がある場合は FTS を使う専用Repositoryへ委譲。
       return this.deps.searchRepository.searchEntries({
         userId: input.userId,
         query,
@@ -36,6 +37,7 @@ export class SearchEntries {
       });
     }
 
+    // 検索語なしは通常一覧（filter）を使う。
     return this.deps.entryRepository.listByFilter({
       userId: input.userId,
       feedId: input.feedId,

--- a/src/application/use-cases/toggle-bookmark.ts
+++ b/src/application/use-cases/toggle-bookmark.ts
@@ -16,6 +16,7 @@ export class ToggleBookmark {
   constructor(private readonly deps: ToggleBookmarkDependencies) {}
 
   async execute(input: ToggleBookmarkInput): Promise<UserEntry> {
+    // 他人のentryを更新できないよう、対象の所属を検証する。
     const entry = await this.deps.entryRepository.findByIdForUser({
       userId: input.userId,
       entryId: input.entryId,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,8 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 
+// Auth.js のエントリポイント。
+// route handler 側は `auth()` を呼ぶだけでセッションを取得できる。
 export const { handlers, auth, signIn, signOut } = NextAuth({
   session: {
     strategy: "jwt",
@@ -13,6 +15,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   ],
   callbacks: {
     async session({ session, token }) {
+      // API 層で user.id を使うため、JWT sub を session に移し替える。
       if (session.user && token.sub) {
         session.user.id = token.sub;
       }

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -1,3 +1,5 @@
+// ドメイン層の純粋な型定義。
+// ここでは Next.js / DB / zod など外部依存を持たない。
 export * from "./entry";
 export * from "./entry-tag";
 export * from "./feed";

--- a/src/infrastructure/db/repository-factory.ts
+++ b/src/infrastructure/db/repository-factory.ts
@@ -30,6 +30,9 @@ export interface RepositorySet {
 }
 
 export function createRepositories(): RepositorySet {
+  // 実行環境に応じて実装を切り替える。
+  // - 本番/接続済み: Turso実装
+  // - ローカル簡易検証: in-memory実装
   if (isTursoConfigured()) {
     return {
       feedRepository: new TursoFeedRepository(),

--- a/src/infrastructure/db/turso-client.ts
+++ b/src/infrastructure/db/turso-client.ts
@@ -3,6 +3,7 @@ import { createClient, type Client } from "@libsql/client";
 let client: Client | null = null;
 
 export function isTursoConfigured(): boolean {
+  // 2つ揃っているときだけ Turso 実装を有効化する。
   return Boolean(process.env.TURSO_DATABASE_URL && process.env.TURSO_AUTH_TOKEN);
 }
 

--- a/src/infrastructure/db/turso-user-repository.ts
+++ b/src/infrastructure/db/turso-user-repository.ts
@@ -76,6 +76,7 @@ export class TursoUserRepository implements UserRepository {
     name?: string | null;
     image?: string | null;
   }): Promise<User> {
+    // Auth.js の user.id を優先して使うため、id指定があればまずそれで存在確認する。
     if (input.id) {
       const existingById = await this.findById(input.id);
       if (existingById) {
@@ -91,6 +92,7 @@ export class TursoUserRepository implements UserRepository {
         INSERT INTO users (id, email, name, image, created_at)
         VALUES (?, ?, ?, ?, ?)
         ON CONFLICT(email) DO UPDATE SET
+          -- email重複時は profile情報だけ更新し、id は既存を維持する。
           name = COALESCE(excluded.name, users.name),
           image = COALESCE(excluded.image, users.image)
       `,

--- a/src/interface/http/auth-user.ts
+++ b/src/interface/http/auth-user.ts
@@ -16,6 +16,8 @@ export class InvalidSessionError extends Error {
 }
 
 export async function requireUserId(): Promise<string> {
+  // API の共通認証ゲート。
+  // route.ts からはこの関数だけ呼べば「認証 + users整合」を担保できる。
   const session = await auth();
   const user = session?.user;
   const userId = user?.id;
@@ -27,6 +29,7 @@ export async function requireUserId(): Promise<string> {
     throw new InvalidSessionError();
   }
 
+  // 外部キー(user_id -> users.id)で失敗しないよう、認証済みユーザーを必ず作成/更新する。
   const repositories = createRepositories();
   await repositories.userRepository.create({
     id: userId,

--- a/src/interface/http/schemas/register-feed-schema.ts
+++ b/src/interface/http/schemas/register-feed-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+// route層で受け取るJSONのバリデーション定義。
 export const registerFeedSchema = z.object({
   url: z.string().url(),
   folderId: z.string().uuid().nullable().optional(),

--- a/src/interface/http/schemas/search-entries-query-schema.ts
+++ b/src/interface/http/schemas/search-entries-query-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+// クエリ文字列はすべて string で届くため、ここで型変換も行う。
 const unreadSchema = z
   .enum(["1", "0", "true", "false"])
   .optional()

--- a/src/interface/http/use-case-factory.ts
+++ b/src/interface/http/use-case-factory.ts
@@ -8,6 +8,8 @@ import {
 import { createRepositories } from "@/infrastructure/db";
 import { RssFetcherHttp } from "@/infrastructure/rss/rss-fetcher-http";
 
+// route.ts から use case を作る入口。
+// 依存注入ポイントを1箇所に寄せることで、各routeの責務を薄く保つ。
 const repositories = createRepositories();
 
 const rssFetcher = new RssFetcherHttp();

--- a/src/interface/ui/components/home-client.tsx
+++ b/src/interface/ui/components/home-client.tsx
@@ -78,10 +78,12 @@ export function HomeClient() {
   const queryClient = useQueryClient();
   const { draftUrl, setDraftUrl, clear } = useFeedFormStore();
 
+  // UIローカル状態（検索条件や操作中のentry）は React state で管理。
   const [search, setSearch] = useState("");
   const [unreadOnly, setUnreadOnly] = useState(false);
   const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
 
+  // Server state は TanStack Query で管理する。
   const entriesQuery = useQuery({
     queryKey: ["entries", { unreadOnly, search }],
     queryFn: () => fetchEntries({ unreadOnly, search }),
@@ -91,6 +93,7 @@ export function HomeClient() {
     mutationFn: createFeed,
     onSuccess: async () => {
       clear();
+      // Feed追加後は一覧を再取得して表示を同期する。
       await queryClient.invalidateQueries({ queryKey: ["entries"] });
     },
   });
@@ -104,6 +107,7 @@ export function HomeClient() {
       await postEntryAction(input.entryId, input.action);
     },
     onSuccess: async () => {
+      // read/bookmark 操作後も一覧を再取得する。
       await queryClient.invalidateQueries({ queryKey: ["entries"] });
     },
     onSettled: () => {

--- a/src/interface/ui/providers.tsx
+++ b/src/interface/ui/providers.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode, useState } from "react";
 
 export function Providers({ children }: { children: ReactNode }) {
+  // QueryClient は再レンダー毎に作らないよう useState 初期化子で1回だけ生成する。
   const [queryClient] = useState(
     () =>
       new QueryClient({

--- a/src/interface/ui/stores/feed-form-store.ts
+++ b/src/interface/ui/stores/feed-form-store.ts
@@ -6,6 +6,7 @@ interface FeedFormState {
   clear: () => void;
 }
 
+// フィード登録フォームの入力だけを保持する最小Zustandストア。
 export const useFeedFormStore = create<FeedFormState>((set) => ({
   draftUrl: "",
   setDraftUrl: (url) => set({ draftUrl: url }),


### PR DESCRIPTION
Closes #18

## Summary
- add a beginner-friendly code reading guide for Next.js + clean architecture
- add explanatory comments to key files across layers:
  - route handlers
  - use cases
  - ports
  - repository factory and Turso adapter
  - auth/session handling
  - UI providers and state hooks

## Verification
- npm run lint
- npm run build
