### PR TITLE
WIP: Unit Test Expansion for Complex UseCases (Phase 2)

### DIFF
--- a/src/application/use-cases/__tests__/export-opml.test.ts
+++ b/src/application/use-cases/__tests__/export-opml.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { ExportOpml } from "../export-opml";
+import type { FeedRepository, OpmlService } from "@/application/ports";
+import type { Feed } from "@/domain/entities";
+
+function createMockDeps() {
+  return {
+    feedRepository: {
+      listByUserId: vi.fn(),
+    } as unknown as FeedRepository,
+    opmlService: {
+      build: vi.fn(),
+    } as unknown as OpmlService,
+  };
+}
+
+const fakeFeeds: Feed[] = [
+  {
+    id: "feed-1",
+    url: "https://example1.com/rss",
+    title: "Feed 1",
+    siteUrl: "https://example1.com",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastFetchedAt: null,
+    etag: null,
+    lastModified: null,
+  },
+  {
+    id: "feed-2",
+    url: "https://example2.com/rss",
+    title: "Feed 2",
+    siteUrl: null, // htmlUrl が無い場合を想定
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastFetchedAt: null,
+    etag: null,
+    lastModified: null,
+  },
+];
+
+describe("ExportOpml UseCase", () => {
+  it("正常系: ユーザーのフィードを取得し、OPML形式で出力する", async () => {
+    // ── Arrange ──
+    const deps = createMockDeps();
+    const useCase = new ExportOpml(deps);
+
+    vi.mocked(deps.feedRepository.listByUserId).mockResolvedValue(fakeFeeds);
+    vi.mocked(deps.opmlService.build).mockResolvedValue(
+      "<opml>fake xml</opml>",
+    );
+
+    // ── Act ──
+    const result = await useCase.execute({ userId: "user-1" });
+
+    // ── Assert ──
+    expect(result).toBe("<opml>fake xml</opml>");
+
+    // Repository が呼ばれたか
+    expect(deps.feedRepository.listByUserId).toHaveBeenCalledWith("user-1");
+
+    // OpmlService.build に渡された引数の検証
+    expect(deps.opmlService.build).toHaveBeenCalledWith([
+      {
+        title: "Feed 1",
+        xmlUrl: "https://example1.com/rss",
+        htmlUrl: "https://example1.com",
+      },
+      {
+        title: "Feed 2",
+        xmlUrl: "https://example2.com/rss",
+        htmlUrl: undefined,
+      },
+    ]);
+  });
+});

--- a/src/application/use-cases/__tests__/import-opml.test.ts
+++ b/src/application/use-cases/__tests__/import-opml.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from "vitest";
+import { ImportOpml } from "../import-opml";
+import type {
+  FeedRepository,
+  FolderRepository,
+  OpmlService,
+  ParsedOpmlSubscription,
+} from "@/application/ports";
+import type { Feed, Folder } from "@/domain/entities";
+
+// ==========================================================================
+// 【テストガイドライン: ImportOpml】
+//
+// 1. ループ内処理のテスト
+//    - OPML 登録は複数のフィードをループで処理します。
+//    - 「1件目は新規フォルダ」「2件目は既存フォルダ」といった複合的なシナリオをテストします。
+//
+// 2. キャッシュロジックの検証
+//    - ImportOpml は内部でフォルダのキャッシュ（Map）を持っています。
+//    - 同じフォルダ名のフィードが複数あるとき、FolderRepository.create が
+//      重複して呼ばれないことを確認するのがポイントです。
+//
+// 3. 部分失敗 (Resilience)
+//    - 途中のフィード登録でエラーが起きても、処理が中断されずに最後まで
+//      実行されるか（importedCount が正しくカウントされるか）を検証します。
+// ==========================================================================
+
+function createMockDeps() {
+  return {
+    opmlService: {
+      parse: vi.fn(),
+      build: vi.fn(),
+    } as unknown as OpmlService,
+    feedRepository: {
+      findByUrl: vi.fn(),
+      create: vi.fn(),
+      createSubscription: vi.fn(),
+    } as unknown as FeedRepository,
+    folderRepository: {
+      listByUserId: vi.fn(),
+      create: vi.fn(),
+    } as unknown as FolderRepository,
+  };
+}
+
+// テスト用ダミーデータ
+const fakeFolder: Folder = {
+  id: "folder-1",
+  userId: "user-1",
+  name: "ニュース",
+  createdAt: new Date(),
+};
+
+const fakeFeed: Feed = {
+  id: "feed-1",
+  url: "https://example.com/rss",
+  title: "Example Feed",
+  siteUrl: "https://example.com",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  lastFetchedAt: null,
+  etag: null,
+  lastModified: null,
+};
+
+describe("ImportOpml UseCase", () => {
+  it("正常系: OPMLをパースし、フォルダとフィードを作成してインポートする", async () => {
+    // ── Arrange (準備) ──
+    const deps = createMockDeps();
+    const useCase = new ImportOpml(deps);
+
+    // 1. OPMLパース結果の準備
+    const parsedSubs: ParsedOpmlSubscription[] = [
+      {
+        title: "Tech News",
+        xmlUrl: "https://tech.example.com/feed",
+        folderName: "IT",
+      },
+    ];
+    vi.mocked(deps.opmlService.parse).mockResolvedValue(parsedSubs);
+
+    // 2. リポジトリの挙動設定
+    vi.mocked(deps.folderRepository.listByUserId).mockResolvedValue([]); // 最初はフォルダなし
+    vi.mocked(deps.folderRepository.create).mockResolvedValue({
+      ...fakeFolder,
+      name: "IT",
+    });
+    vi.mocked(deps.feedRepository.findByUrl).mockResolvedValue(null); // 新規フィード
+    vi.mocked(deps.feedRepository.create).mockResolvedValue(fakeFeed);
+
+    // ── Act (実行) ──
+    const result = await useCase.execute({
+      userId: "user-1",
+      opmlContent: "<opml>...</opml>",
+    });
+
+    // ── Assert (検証) ──
+    expect(result.importedCount).toBe(1);
+
+    // フォルダが作成されたか
+    expect(deps.folderRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "IT" }),
+    );
+    // フィードと購読が作成されたか
+    expect(deps.feedRepository.create).toHaveBeenCalled();
+    expect(deps.feedRepository.createSubscription).toHaveBeenCalled();
+  });
+
+  it("正常系: フォルダがすでに存在する場合は再利用する", async () => {
+    // ── Arrange (準備) ──
+    const deps = createMockDeps();
+    const useCase = new ImportOpml(deps);
+
+    // 1. OPMLパース結果の準備
+    const parsedSubs: ParsedOpmlSubscription[] = [
+      {
+        title: "Tech News",
+        xmlUrl: "https://tech.example.com/feed",
+        folderName: "IT",
+      },
+    ];
+
+    // すでに存在するfolder
+    const fakeFolder = {
+      id: "folder-1",
+      userId: "user-1",
+      name: "IT",
+      createdAt: new Date(),
+    };
+
+    const fakeFeed = {
+      id: "feed-1",
+      url: "https://tech.example.com/feed",
+      title: "Tech News",
+      siteUrl: "https://tech.example.com",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      lastFetchedAt: null,
+      etag: null,
+      lastModified: null,
+    };
+
+    vi.mocked(deps.opmlService.parse).mockResolvedValue(parsedSubs);
+
+    // 2. リポジトリの挙動設定
+    vi.mocked(deps.folderRepository.listByUserId).mockResolvedValue([
+      fakeFolder,
+    ]);
+
+    vi.mocked(deps.folderRepository.create).mockResolvedValue({
+      ...fakeFolder,
+    });
+    vi.mocked(deps.feedRepository.findByUrl).mockResolvedValue(null); // 新規フィード
+    vi.mocked(deps.feedRepository.create).mockResolvedValue(fakeFeed);
+
+    // ── Act (実行) ──
+    const result = await useCase.execute({
+      userId: "user-1",
+      opmlContent: "<opml>...</opml>",
+    });
+
+    // ── Assert (検証) ──
+    expect(result.importedCount).toBe(1);
+
+    // すでに存在するフォルダを利用したか
+    expect(deps.folderRepository.create).not.toHaveBeenCalled();
+    // フィードと購読が作成された
+    expect(deps.feedRepository.create).toHaveBeenCalled();
+    expect(deps.feedRepository.createSubscription).toHaveBeenCalled();
+  });
+
+  it("ロバスト性: 一部のフィード登録が失敗(createSubscriptionに失敗)しても、他の登録を続行する", async () => {
+    // 「1件エラーが起きても importedCount が増えること」
+    const deps = createMockDeps();
+    const useCase = new ImportOpml(deps);
+
+    // 2件のフィード
+    const parsedSubs: ParsedOpmlSubscription[] = [
+      { title: "Fail Feed", xmlUrl: "https://fail.com/rss" },
+      { title: "Success Feed", xmlUrl: "https://success.com/rss" },
+    ];
+    vi.mocked(deps.opmlService.parse).mockResolvedValue(parsedSubs);
+    vi.mocked(deps.folderRepository.listByUserId).mockResolvedValue([]);
+    // 2. 1件目の購読作成でわざとエラーを投げる
+    vi.mocked(deps.feedRepository.findByUrl).mockResolvedValue(null); //新規feed
+    vi.mocked(deps.feedRepository.create).mockResolvedValue(fakeFeed);
+    vi.mocked(deps.feedRepository.createSubscription)
+      .mockRejectedValueOnce(new Error("DB Error")) // 1回目は失敗
+      .mockResolvedValueOnce({} as any); // 2回目は成功
+
+    //Act
+    const result = await useCase.execute({
+      userId: "user-1",
+      opmlContent: "<opml>...</opml>",
+    });
+
+    //Assert
+    // 1件失敗しても残りはOK
+    expect(result.importedCount).toBe(1);
+
+    // createSubscriptionは二回呼ばれる
+    expect(deps.feedRepository.createSubscription).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/application/use-cases/__tests__/register-feed.test.ts
+++ b/src/application/use-cases/__tests__/register-feed.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from "vitest";
+import { RegisterFeed, InvalidFeedUrlError } from "../register-feed";
+import type {
+  FeedRepository,
+  EntryRepository,
+  RssFetcher,
+  SearchRepository,
+} from "@/application/ports";
+import type { Feed, Subscription, Entry } from "@/domain/entities";
+
+// ==========================================================================
+// 【テストガイドライン: RegisterFeed】
+//
+// 1. モック (Mocking)
+//    - UseCase が依存するリポジトリやサービスはすべて vi.fn() でモック化します。
+//    - データベースやネットワーク通信を実際に行わずに、挙動をシミュレートします。
+//
+// 2. AAAパターン (Arrange, Act, Assert)
+//    - Arrange (準備): モックの戻り値設定や入力データの用意。
+//    - Act (実行): テスト対象のメソッドを呼び出す。
+//    - Assert (検証): 期待した結果になったか、依存先が正しく呼ばれたかを確認。
+//
+// 3. 境界条件の検証
+//    - 正常系だけでなく、空文字、不正なURL、外部エラーなどの異常系も網羅します。
+// ==========================================================================
+
+function createMockDeps() {
+  return {
+    feedRepository: {
+      findByUrl: vi.fn(),
+      create: vi.fn(),
+      updateFetchMetadata: vi.fn(),
+      createSubscription: vi.fn(),
+    } as unknown as FeedRepository,
+    entryRepository: {
+      listByFilter: vi.fn(),
+      saveFetchedEntries: vi.fn(),
+    } as unknown as EntryRepository,
+    rssFetcher: {
+      fetchFeed: vi.fn(),
+    } as unknown as RssFetcher,
+    searchRepository: {
+      indexEntries: vi.fn(),
+    } as unknown as SearchRepository,
+  };
+}
+
+// テスト用ダミーデータ
+const fakeFeed: Feed = {
+  id: "feed-1",
+  url: "https://example.com/rss",
+  title: "Example Feed",
+  siteUrl: "https://example.com",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  lastFetchedAt: null,
+  etag: "fake-etag",
+  lastModified: "2026-02-22",
+};
+
+const fakeSubscription: Subscription = {
+  id: "sub-1",
+  userId: "user-1",
+  feedId: "feed-1",
+  folderId: null,
+  createdAt: new Date(),
+};
+
+const fakeEntry: Entry = {
+  id: "entry-1",
+  feedId: "feed-1",
+  guid: "guid-1",
+  title: "既存の記事",
+  url: "https://example.com/1",
+  content: "内容",
+  author: "著者",
+  publishedAt: new Date(),
+  createdAt: new Date(),
+};
+
+describe("RegisterFeed UseCase", () => {
+  it("正常系: 新規フィードを登録し、記事を保存して購読を作成する", async () => {
+    // ── Arrange (準備) ──
+    const deps = createMockDeps();
+    const useCase = new RegisterFeed(deps);
+
+    // 1. フィードがまだ存在しない (null)
+    vi.mocked(deps.feedRepository.findByUrl).mockResolvedValue(null);
+    // 2. RSSフェッチャーが成功レスポンスを返す
+    vi.mocked(deps.rssFetcher.fetchFeed).mockResolvedValue({
+      title: "Example Feed",
+      siteUrl: "https://example.com",
+      entries: [
+        { guid: "guid-1", title: "記事1", url: "https://example.com/1" },
+      ],
+      notModified: false,
+    });
+    // 3. 各リポジトリの作成・保存処理
+    vi.mocked(deps.feedRepository.create).mockResolvedValue(fakeFeed);
+    vi.mocked(deps.entryRepository.listByFilter).mockResolvedValue([]); // DBが空であることを示す
+    vi.mocked(deps.entryRepository.saveFetchedEntries).mockResolvedValue([
+      "entry-1",
+    ]);
+    vi.mocked(deps.feedRepository.createSubscription).mockResolvedValue(
+      fakeSubscription,
+    );
+
+    // ── Act (実行) ──
+    const result = await useCase.execute({
+      userId: "user-1",
+      url: "https://example.com/rss",
+    });
+
+    // ── Assert (検証) ──
+    // 1. 戻り値の確認
+    expect(result.feed.id).toBe("feed-1");
+    expect(result.insertedEntryCount).toBe(1);
+
+    // 2. 依存関係の呼び出し確認
+    expect(deps.rssFetcher.fetchFeed).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://example.com/rss" }),
+    );
+    expect(deps.entryRepository.saveFetchedEntries).toHaveBeenCalled();
+    expect(deps.searchRepository.indexEntries).toHaveBeenCalledWith([
+      "entry-1",
+    ]);
+    expect(deps.feedRepository.createSubscription).toHaveBeenCalled();
+  });
+
+  it("正常系: Feedがすでに存在して、記事の更新がない場合", async () => {
+    // ── Arrange (準備) ──
+    const deps = createMockDeps();
+    const useCase = new RegisterFeed(deps);
+
+    // 1. フィードがすでに存在する
+    vi.mocked(deps.feedRepository.findByUrl).mockResolvedValue(fakeFeed);
+
+    // 2. DBにはすでに記事がある（空ではない）と設定
+    vi.mocked(deps.entryRepository.listByFilter).mockResolvedValue([fakeEntry]);
+
+    // 3. RSSフェッチャーがnotModified: trueを返すように準備
+    vi.mocked(deps.rssFetcher.fetchFeed).mockResolvedValue({
+      title: "Example Feed",
+      siteUrl: "https://example.com",
+      entries: [],
+      notModified: true,
+    });
+
+    // 3. fetch Meta情報を更新
+    vi.mocked(deps.feedRepository.updateFetchMetadata).mockResolvedValue();
+
+    // ── Act (実行) ──
+    await useCase.execute({
+      userId: "user-1",
+      url: "https://example.com/rss",
+    });
+
+    // ── Assert (検証) ──
+    // fetchFeed が、DBから取得した etag 等を正しく送信しているか？
+    expect(deps.rssFetcher.fetchFeed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com/rss",
+        etag: "fake-etag",
+        lastModified: "2026-02-22",
+      }),
+    );
+
+    // 更新がない(304)のでsaveFetchedEntriesは呼ばれない
+    expect(deps.entryRepository.saveFetchedEntries).not.toHaveBeenCalled();
+
+    // 更新がない場合でもupdateFetchMetadata(最終更新日などの更新)は呼ばれる
+    expect(deps.feedRepository.updateFetchMetadata).toHaveBeenCalled();
+  });
+
+  it("異常系: 不正なURL形式の場合は InvalidFeedUrlError を投げる", async () => {
+    // ── Arrange (準備) ──
+    const deps = createMockDeps();
+    const useCase = new RegisterFeed(deps);
+
+    // ── Act & Assert (実行と検証) ──
+    // execute自体が例外を投げることを検証する場合は、await expect(...).rejects を使います。
+    await expect(
+      useCase.execute({ userId: "user-1", url: "not-a-url" }),
+    ).rejects.toThrow(InvalidFeedUrlError);
+  });
+
+  it("異常系: RSSエッチャーがエラーを返す場合はエラーを投げる", async () => {
+    // Arrange
+    const deps = createMockDeps();
+    const useCase = new RegisterFeed(deps);
+
+    // 1. フィードはまだ存在しない (新規登録ルート)
+    vi.mocked(deps.feedRepository.findByUrl).mockResolvedValue(null);
+
+    const networkError = new Error("Network Error");
+    vi.mocked(deps.rssFetcher.fetchFeed).mockRejectedValue(networkError);
+
+    // Act & Assert
+    await expect(
+      useCase.execute({ userId: "user-1", url: "https://example.com/rss" }),
+    ).rejects.toThrow("Network Error");
+  });
+});

--- a/src/application/use-cases/import-opml.ts
+++ b/src/application/use-cases/import-opml.ts
@@ -48,9 +48,12 @@ export class ImportOpml {
       try {
         // Resolve or create folder
         let folderId: string | null = null;
+        // フォルダ名がある
         if (sub.folderName) {
+          // そのフォルダがすでに存在していれば再利用
           if (folderCache.has(sub.folderName)) {
             folderId = folderCache.get(sub.folderName) || null;
+            //　新たなフォルダならば新規作成
           } else {
             const newFolder = await this.deps.folderRepository.create({
               userId: input.userId,
@@ -65,6 +68,7 @@ export class ImportOpml {
         let feed: Feed | null = await this.deps.feedRepository.findByUrl(
           sub.xmlUrl,
         );
+        //DBにfeedが存在しない
         if (!feed) {
           feed = await this.deps.feedRepository.create({
             url: sub.xmlUrl,
@@ -77,7 +81,7 @@ export class ImportOpml {
         await this.deps.feedRepository.createSubscription({
           userId: input.userId,
           feedId: feed.id,
-          folderId,
+          folderId, // folderが存在しなければNull
         });
 
         importedCount++;


### PR DESCRIPTION
closes #25

## 概要
ビジネスロジックが複雑な UseCase の単体テスト拡充（フェーズ2）の作業用 PR です。

## 作業状況
- [x] RegisterFeed の単体テスト実装（正常系・異常系・304制御）
- [x] ImportOpml の単体テスト実装（現在作業中）

## 今後の予定
- ImportOpml のテストケース拡充
- ExportOpml のテスト実装
- 必要に応じてリファクタリング