### PR TITLE
feat(ui): AI要約機能のUI/UX改善とコンポーネントのリファクタリング

### DIFF
--- a/src/interface/ui/components/entry-item.tsx
+++ b/src/interface/ui/components/entry-item.tsx
@@ -3,7 +3,6 @@ import remarkGfm from "remark-gfm";
 
 interface EntryItemProps {
   entry: EntryItemType;
-  summaries: Record<string, string | null>;
   activeEntryId: string | null;
   // call entryActionMutation.mutate
   onAction: (entryId: string, action: "read" | "unread" | "bookmark" | "unbookmark") => void;
@@ -23,10 +22,26 @@ interface EntryItemType {
   summary?: string | null;
 }
 
+// ボタン用スピナー
+const Spinner = () => (
+  <svg className="animate-spin -ml-1 mr-2 h-3 w-3 text-slate-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+  </svg>
+);
+
+// 要約エリア用スケルトン
+const SummarySkeleton = () => (
+  <div className="mt-2 rounded bg-slate-50 p-3 animate-pulse space-y-2">
+    <div className="h-2 bg-slate-200 rounded w-full"></div>
+    <div className="h-2 bg-slate-200 rounded w-5/6"></div>
+    <div className="h-2 bg-slate-200 rounded w-4/6"></div>
+  </div>
+);
+
 // 各記事ごとのcomponent
 export function EntryItem({
   entry,
-  summaries,
   activeEntryId,
   onAction,
   onSummarize,
@@ -36,7 +51,7 @@ export function EntryItem({
   const isCurrentActive = activeEntryId === entry.id;
 
   return (
-    <li key={entry.id} className="rounded-md border border-slate-200 p-3">
+    <li className="rounded-md border border-slate-200 p-3">
       <a href={entry.url} target="_blank" rel="noreferrer" className="font-medium text-slate-900 underline">
         {entry.title}
       </a>
@@ -45,12 +60,13 @@ export function EntryItem({
         {entry.publishedAt ? ` / ${new Date(entry.publishedAt).toLocaleString()}` : ""}
       </p>
 
-      {/* 要約表示（UIキャッシュ or サーバ返却分） */}
-      {(summaries[entry.id] ?? entry.summary) ? (
+      {/* 要約表示（ローディング中はスケルトンを表示） */}
+      {isSummarizePending && isCurrentActive ? (
+        <SummarySkeleton />
+      ) : entry.summary ? (
         <div className="mt-2 rounded bg-slate-50 p-2 text-sm text-slate-700 prose prose-slate max-w-none">
-
           <ReactMarkdown remarkPlugins={[remarkGfm]}>
-            {(summaries[entry.id] ?? entry.summary) ?? ""}
+            {entry.summary}
           </ReactMarkdown>
         </div>
       ) : null}
@@ -68,14 +84,21 @@ export function EntryItem({
           </button>
         ))}
 
-        {/* 要約ボタン */}
+        {/* 要約ボタン（ローディング中はスピナーを表示） */}
         <button
           type="button"
           onClick={() => onSummarize(entry.id)}
           disabled={isSummarizePending && isCurrentActive}
-          className="rounded-md border border-slate-300 px-2 py-1 text-xs"
+          className="inline-flex items-center rounded-md border border-slate-300 px-2 py-1 text-xs"
         >
-          {isSummarizePending && isCurrentActive ? "Summarizing..." : "Summarize"}
+          {isSummarizePending && isCurrentActive ? (
+            <>
+              <Spinner />
+              Summarizing...
+            </>
+          ) : (
+            "Summarize"
+          )}
         </button>
       </div>
     </li>


### PR DESCRIPTION
## 概要
AI要約機能のUI/UXを大幅に改善し、コードベースをリファクタリングしました。

## 変更内容
### UI/UXの強化
- **マークダウン表示**: AIが生成する箇条書きや太字を正しく表示するため、`react-markdown` を導入。
- **ローディングフィードバック**: 
  - 要約実行中に要約エリアへスケルトンを表示。
  - 要約ボタンおよびフィード追加ボタンへスピナー（回転アイコン）を導入。
- **エラーハンドリングの精密化**:
  - APIのレート制限（429）を具体的にユーザーへ通知。
  - エラー表示を Tailwind CSS のアラートスタイルに刷新。
  - 他の操作を行った際に自動的に既存のエラーをクリアする挙動を実装。

### コードのリファクタリング
- **EntryItem コンポーネントの抽出**: `home-client.tsx` の肥大化を解消。
- **Query Cache の一本化**: `useState` による手動キャッシュを廃止し、TanStack Query の `setQueryData` による即時更新（Optimistic UI 的な挙動）へ移行。

## 検証内容
- [x] `npm run test` ですべてのテスト（42件）がパスすることを確認。
- [x] 手動でのマークダウン表示、ローディング表示、エラークリア挙動を確認。

Fixes #31